### PR TITLE
Separate flag for migrations directory

### DIFF
--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -14,7 +14,7 @@ import (
 var flagPath = flag.String("path", "db", "folder containing db info")
 var flagEnv = flag.String("env", "development", "which DB environment to use")
 var flagPgSchema = flag.String("pgschema", "", "which postgres-schema to migrate (default = none)")
-var flagMigrationsPath = flag.String("migrations", "", "folder containing db migrations (default = none)")
+var flagMigrationsPath = flag.String("migrations", "", "folder containing db migrations (default = [path]/migrations)")
 
 // helper to create a DBConf from the given flags
 func dbConfFromFlags() (dbconf *goose.DBConf, err error) {

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -1,22 +1,31 @@
 package main
 
 import (
-	"github.com/snikch/goose/lib/goose"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 	"text/template"
+
+	"github.com/snikch/goose/lib/goose"
 )
 
 // global options. available to any subcommands.
 var flagPath = flag.String("path", "db", "folder containing db info")
 var flagEnv = flag.String("env", "development", "which DB environment to use")
 var flagPgSchema = flag.String("pgschema", "", "which postgres-schema to migrate (default = none)")
+var flagMigrationsPath = flag.String("migrations", "", "folder containing db migrations (default = none)")
 
 // helper to create a DBConf from the given flags
 func dbConfFromFlags() (dbconf *goose.DBConf, err error) {
-	return goose.NewDBConf(*flagPath, *flagEnv, *flagPgSchema)
+	conf, err := goose.NewDBConf(*flagPath, *flagEnv, *flagPgSchema)
+	if err != nil {
+		return nil, err
+	}
+	if *flagMigrationsPath != "" {
+		conf.MigrationsDir = *flagMigrationsPath
+	}
+	return conf, nil
 }
 
 var commands = []*Command{

--- a/cmd/goose/main.go
+++ b/cmd/goose/main.go
@@ -14,7 +14,7 @@ import (
 var flagPath = flag.String("path", "db", "folder containing db info")
 var flagEnv = flag.String("env", "development", "which DB environment to use")
 var flagPgSchema = flag.String("pgschema", "", "which postgres-schema to migrate (default = none)")
-var flagMigrationsPath = flag.String("migrations", "", "folder containing db migrations (default = [path]/migrations)")
+var flagMigrationsPath = flag.String("migrations", "", "folder containing db migrations (default = \"[path]/migrations\")")
 
 // helper to create a DBConf from the given flags
 func dbConfFromFlags() (dbconf *goose.DBConf, err error) {

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -35,7 +35,6 @@ func NewDBConf(p, env string, pgschema string) (*DBConf, error) {
 	f, err := yaml.ReadFile(cfgFile)
 	if err != nil {
 		return nil, err
-
 	}
 
 	drv, err := f.Get(fmt.Sprintf("%s.driver", env))

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -34,7 +34,11 @@ func NewDBConf(p, env string, pgschema string) (*DBConf, error) {
 
 	f, err := yaml.ReadFile(cfgFile)
 	if err != nil {
-		return nil, err
+		cfgFile = filepath.Join("etc", "dbconf.yml")
+		f, err = yaml.ReadFile(cfgFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	drv, err := f.Get(fmt.Sprintf("%s.driver", env))

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -34,12 +34,8 @@ func NewDBConf(p, env string, pgschema string) (*DBConf, error) {
 
 	f, err := yaml.ReadFile(cfgFile)
 	if err != nil {
-		p = os.Getenv("DBCONF_DIRECTORY")
-		cfgFile = filepath.Join(p, "dbconf.yml")
-		f, err = yaml.ReadFile(cfgFile)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+
 	}
 
 	drv, err := f.Get(fmt.Sprintf("%s.driver", env))

--- a/lib/goose/dbconf.go
+++ b/lib/goose/dbconf.go
@@ -34,7 +34,8 @@ func NewDBConf(p, env string, pgschema string) (*DBConf, error) {
 
 	f, err := yaml.ReadFile(cfgFile)
 	if err != nil {
-		cfgFile = filepath.Join("etc", "dbconf.yml")
+		p = os.Getenv("DBCONF_DIRECTORY")
+		cfgFile = filepath.Join(p, "dbconf.yml")
 		f, err = yaml.ReadFile(cfgFile)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Right now we're maintaining 2 copies of the dbconf.yml file (or use a symlink). One in the `etc` folder for deployment the other in the `db` folder for use with the goose CLI.
With this, if reading from `db` fails, goose will try `etc` so we can have just one file.
This is the most naive but also the quickest method of achieving what we need but I'm happy to adopt a different approach if you think this is too simplistic.

cc: @edsrzf