### PR TITLE
enable dry run

### DIFF
--- a/lib/goose/dialect.go
+++ b/lib/goose/dialect.go
@@ -11,7 +11,7 @@ import (
 type SqlDialect interface {
 	createVersionTableSql() string // sql string to create the goose_db_version table
 	insertVersionSql() string      // sql string to insert the initial version table row
-	dbVersionQuery(db *sql.DB) (*sql.Rows, error)
+	DBVersionQuery(db *sql.DB) (*sql.Rows, error)
 }
 
 // drivers that we don't know about can ask for a dialect by name
@@ -48,7 +48,7 @@ func (pg PostgresDialect) insertVersionSql() string {
 	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
 }
 
-func (pg PostgresDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
+func (pg PostgresDialect) DBVersionQuery(db *sql.DB) (*sql.Rows, error) {
 	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
 
 	// XXX: check for postgres specific error indicating the table doesn't exist.
@@ -81,7 +81,7 @@ func (m MySqlDialect) insertVersionSql() string {
 	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES (?, ?);"
 }
 
-func (m MySqlDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
+func (m MySqlDialect) DBVersionQuery(db *sql.DB) (*sql.Rows, error) {
 	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
 
 	// XXX: check for mysql specific error indicating the table doesn't exist.
@@ -114,7 +114,7 @@ func (rs RedshiftDialect) insertVersionSql() string {
 	return "INSERT INTO goose_db_version (version_id, is_applied) VALUES ($1, $2);"
 }
 
-func (rs RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
+func (rs RedshiftDialect) DBVersionQuery(db *sql.DB) (*sql.Rows, error) {
 	rows, err := db.Query("SELECT version_id, is_applied from goose_db_version ORDER BY id DESC")
 	if err, ok := err.(*pq.Error); ok {
 		if err.Code == "42P01" {

--- a/lib/goose/migrate.go
+++ b/lib/goose/migrate.go
@@ -193,7 +193,7 @@ func NumericComponent(name string) (int64, error) {
 // Create and initialize the DB version table if it doesn't exist.
 func EnsureDBVersion(conf *DBConf, db *sql.DB) (int64, error) {
 
-	rows, err := conf.Driver.Dialect.dbVersionQuery(db)
+	rows, err := conf.Driver.Dialect.DBVersionQuery(db)
 	if err != nil {
 		if err == ErrTableDoesNotExist {
 			return 0, createVersionTable(conf, db)


### PR DESCRIPTION
Make the func to determine whether the version table exists public, to enable a dry migration functionality. 